### PR TITLE
chore: 升级Hugo、PaperMod主题及pre-commit钩子版本

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.150.0
+      HUGO_VERSION: 0.161.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: mixed-line-ending # 检查结束符，使用Unix LF
       - id: trailing-whitespace # 取消行尾无关紧要的空格
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.9.1
+    rev: v4.15.1
     hooks:
       - id: commitizen
         stages: [ commit-msg ]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # imleowoo.github.io
+
 LEO'S NOTES


### PR DESCRIPTION
- Hugo 0.150.0 → 0.161.1
- PaperMod 主题更新至最新 commit
- commitizen pre-commit 钩子 v4.9.1 → v4.15.1